### PR TITLE
topology: fix support for disabled MD5 authentication

### DIFF
--- a/Topology/hpnmgt_snmp.c
+++ b/Topology/hpnmgt_snmp.c
@@ -2192,9 +2192,14 @@ HMGT_STATUS_T collect_data(SNMPHost *hosts, SNMPOid *sw_oids, SNMPOid *nic_oids,
 	//Authentication Protocol
 	if ( (secLevel == SNMP_SEC_LEVEL_AUTHNOPRIV) || (secLevel == SNMP_SEC_LEVEL_AUTHPRIV) ) {
 		if (strcmp(fabric->SnmpAuthenticationProtocol, "MD5") == 0) {
+#ifndef NETSNMP_DISABLE_MD5
 			authProtocol = usmHMACMD5AuthProtocol;
 			authProtocolLength = USM_AUTH_PROTO_MD5_LEN;
 			DBGPRINT("Running MD5 authentication \n");
+#else
+			fprintf(stderr, "%s: MD5 authentication selected but disabled in net-snmp\n", __func__);
+			configParseError = 1;
+#endif
 		} else if (strcmp(fabric->SnmpAuthenticationProtocol, "SHA") == 0) {
 			authProtocol = usmHMACSHA1AuthProtocol;
 			authProtocolLength = USM_AUTH_PROTO_SHA_LEN;


### PR DESCRIPTION
net-snmp can be built with disabled MD5 authentication which causes a build failure in eth-ff:
hpnmgt_snmp.c:2142:40: error: 'usmHMACMD5AuthProtocol' undeclared (first use in this function); did you mean 'usmHMACSHA1AuthProtocol'?
 2142 |                         authProtocol = usmHMACMD5AuthProtocol;
      |                                        ^~~~~~~~~~~~~~~~~~~~~~
      |                                        usmHMACSHA1AuthProtocol
hpnmgt_snmp.c:2142:40: note: each undeclared identifier is reported only once for each function it appears in

Use the NETSNMP_DISABLE_MD5 flag to detect this use case and output a comprehensible error to user.

Signed-off-by: Nicolas Morey <nmorey@suse.com>